### PR TITLE
fix: fix QjsEngine::loadFile error handling

### DIFF
--- a/backend/QuickJs/QjsEngine.cc
+++ b/backend/QuickJs/QjsEngine.cc
@@ -293,7 +293,17 @@ Local<Value> QjsEngine::loadFile(const Local<String>& scriptFile) {
   JSValue ret = JS_Eval(context_, contentStr.c_str(), contentStr.length(), fileNameStr.c_str(),
                         JS_EVAL_TYPE_MODULE);
 
+  // Syntax error
   qjs_backend::checkException(ret);
+
+  // Error occurred during loading
+  JSPromiseStateEnum state = JS_PromiseState(context_, ret);
+  if (state == JSPromiseStateEnum::JS_PROMISE_REJECTED) {
+    JSValue msg = JS_PromiseResult(context_, ret);
+    JS_Throw(context_, msg);
+    qjs_backend::checkException(-1);
+  }
+
   scheduleTick();
 
   return Local<Value>(ret);


### PR DESCRIPTION
初步修复 QjsEngine::loadFile 的错误判断
可能还需要一些处理：
- 如果使用到顶层await的特性，这时返回的Promise是挂起状态的，无法实时判断，该怎么处理
- 其他情况下  qjs_backend::checkException 是否应该判断被拒绝的Promise并抛出异常